### PR TITLE
[Validator] Support SVGs when validating image dimensions

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 6.1
 ---
-
+ 
+ * Support `SVGs` when validating image dimensions
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
 
 6.0

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -53,7 +53,11 @@ class ImageValidator extends FileValidator
             return;
         }
 
-        $size = @getimagesize($value);
+        if ($this->isSvg($value)) {
+            $size = $this->getSvgSize($value);
+        } else {
+            $size = @getimagesize($value);
+        }
 
         if (empty($size) || (0 === $size[0]) || (0 === $size[1])) {
             $this->context->buildViolation($constraint->sizeNotDetectedMessage)
@@ -233,5 +237,30 @@ class ImageValidator extends FileValidator
 
             imagedestroy($resource);
         }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    private function isSvg($value)
+    {
+        return 'image/svg+xml' === mime_content_type($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array
+     */
+    private function getSvgSize($value)
+    {
+        $xmlValue = simplexml_load_file($value);
+        $svgAttributes = $xmlValue->attributes();
+        $width = (string) $svgAttributes->width;
+        $height = (string) $svgAttributes->height;
+
+        return [$width, $height];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1" height="1" viewBox="0 0 1 1">
+
+<g />
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -29,6 +29,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     protected $imagePortrait;
     protected $image4By3;
     protected $imageCorrupted;
+    protected $imageSvg;
 
     protected function createValidator()
     {
@@ -45,6 +46,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->image4By3 = __DIR__.'/Fixtures/test_4by3.gif';
         $this->image16By9 = __DIR__.'/Fixtures/test_16by9.gif';
         $this->imageCorrupted = __DIR__.'/Fixtures/test_corrupted.gif';
+        $this->imageSvg = __DIR__.'/Fixtures/test_svg.svg';
     }
 
     public function testNullIsValid()
@@ -516,6 +518,34 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setCode(Image::CORRUPTED_IMAGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testSvgSize()
+    {
+        $constraint = new Image([
+            'minWidth' => 1,
+            'maxWidth' => 2,
+            'minHeight' => 1,
+            'maxHeight' => 2,
+        ]);
+
+        $this->validator->validate($this->imageSvg, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider provideAllowSquareConstraints
+     */
+    public function testSquareNotAllowedOnSvg(Image $constraint)
+    {
+        $this->validator->validate($this->imageSvg, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 1)
+            ->setParameter('{{ height }}', 1)
+            ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
             ->assertRaised();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #45269
| License       | MIT
| Doc PR        | 

Add SVG support in Image Validator
